### PR TITLE
[fix] 제품/세차장 리뷰 도메인에 비속어 필터링 적용 및 글로벌 Exception 수정 

### DIFF
--- a/module-api/src/main/java/com/kernel360/review/dto/ReviewRequestDto.java
+++ b/module-api/src/main/java/com/kernel360/review/dto/ReviewRequestDto.java
@@ -1,5 +1,6 @@
 package com.kernel360.review.dto;
 
+import com.kernel360.code.common.ValidationMessage;
 import com.kernel360.global.annotation.BadWordFilter;
 import com.kernel360.member.entity.Member;
 import com.kernel360.product.entity.Product;
@@ -16,10 +17,8 @@ public record ReviewRequestDto(Long reviewNo,
                                Long productNo,
                                Long memberNo,
                                BigDecimal starRating,
-                               @BadWordFilter
-                               String title,
-                               @BadWordFilter
-                               String contents,
+                               @BadWordFilter(message = ValidationMessage.INVALID_WORD_PARAMETER) String title,
+                               @BadWordFilter(message = ValidationMessage.INVALID_WORD_PARAMETER) String contents,
                                LocalDateTime createdAt,
                                String createdBy,
                                LocalDateTime modifiedAt,

--- a/module-api/src/main/java/com/kernel360/washzonereview/controller/WashzoneReviewController.java
+++ b/module-api/src/main/java/com/kernel360/washzonereview/controller/WashzoneReviewController.java
@@ -5,6 +5,7 @@ import com.kernel360.washzonereview.code.WashzoneReviewBusinessCode;
 import com.kernel360.washzonereview.dto.WashzoneReviewRequestDto;
 import com.kernel360.washzonereview.dto.WashzoneReviewResponseDto;
 import com.kernel360.washzonereview.service.WashzoneReviewService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -47,7 +48,7 @@ public class WashzoneReviewController {
 
     @PostMapping
     public <T> ResponseEntity<ApiResponse<T>> createWashzoneReview(
-            @RequestPart WashzoneReviewRequestDto washzoneReview,
+            @Valid @RequestPart WashzoneReviewRequestDto washzoneReview,
             @RequestPart(required = false) List<MultipartFile> files,
             @RequestHeader("Id") String id) {
         washzoneReviewService.createWashzoneReview(washzoneReview, files, id);
@@ -57,7 +58,7 @@ public class WashzoneReviewController {
 
     @PatchMapping
     public <T> ResponseEntity<ApiResponse<T>> updateWashzoneReview(
-            @RequestPart WashzoneReviewRequestDto washzoneReview,
+            @Valid @RequestPart WashzoneReviewRequestDto washzoneReview,
             @RequestPart(required = false) List<MultipartFile> files,
             @RequestHeader("Id") String id) {
         washzoneReviewService.updateWashzoneReview(washzoneReview, files, id);

--- a/module-api/src/main/java/com/kernel360/washzonereview/dto/WashzoneReviewRequestDto.java
+++ b/module-api/src/main/java/com/kernel360/washzonereview/dto/WashzoneReviewRequestDto.java
@@ -1,5 +1,7 @@
 package com.kernel360.washzonereview.dto;
 
+import com.kernel360.code.common.ValidationMessage;
+import com.kernel360.global.annotation.BadWordFilter;
 import com.kernel360.member.entity.Member;
 import com.kernel360.washzone.entity.WashZone;
 import com.kernel360.washzonereview.entity.WashzoneReview;
@@ -15,8 +17,8 @@ public record WashzoneReviewRequestDto(Long washzoneReviewNo,
                                        Long washzoneNo,
                                        Long memberNo,
                                        BigDecimal starRating,
-                                       String title,
-                                       String contents,
+                                       @BadWordFilter(message = ValidationMessage.INVALID_WORD_PARAMETER) String title,
+                                       @BadWordFilter(message = ValidationMessage.INVALID_WORD_PARAMETER) String contents,
                                        LocalDateTime createdAt,
                                        String createdBy,
                                        LocalDateTime modifiedAt,

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
     // aws s3
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.625'
+
+    // commons-lang3
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 tasks.named('test') {

--- a/module-common/src/main/java/com/kernel360/code/common/CommonErrorCode.java
+++ b/module-common/src/main/java/com/kernel360/code/common/CommonErrorCode.java
@@ -12,7 +12,7 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST.value(),  "E006", "요청 파라미터가 없거나 비어있거나, 요청 파라미터의 이름이 메서드 인수의 이름과 일치하지 않습니다"),
     INVALID_HTTP_REQUEST_METHOD(HttpStatus.BAD_REQUEST.value(),  "E007", "요청 URL 에서 지원하지 않는 HTTP Method 입니다."),
     INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST.value(),  "E008", "요청한 파라미터가 존재하지 않음"),
-    INVALID_WORD_PARAMETER(HttpStatus.BAD_REQUEST.value(),  "E009", "비속어를 포함할 수 없습니다.");
+    ARGUMENT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST.value(),  "E009", "유효하지 않은 데이터가 존재함");
 
     private final int status;
     private final String code;

--- a/module-common/src/main/java/com/kernel360/code/common/ValidationMessage.java
+++ b/module-common/src/main/java/com/kernel360/code/common/ValidationMessage.java
@@ -1,0 +1,5 @@
+package com.kernel360.code.common;
+
+public class ValidationMessage {
+    public static final String INVALID_WORD_PARAMETER = "비속어를 포함할 수 없습니다";
+}

--- a/module-common/src/main/java/com/kernel360/handler/GlobalExceptionHandler.java
+++ b/module-common/src/main/java/com/kernel360/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.kernel360.response.ErrorResponse;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -16,7 +17,6 @@ import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
 
 @Slf4j
 @RestControllerAdvice
@@ -77,21 +77,21 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(final IllegalArgumentException e){
-        log.error("handleIllegalArgumentException",e);
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(final IllegalArgumentException e) {
+        log.error("handleIllegalArgumentException", e);
 
         final ErrorResponse response = ErrorResponse.of(CommonErrorCode.INVALID_ARGUMENT);
 
-        return new ResponseEntity<>(response,HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e){
-        log.error("handleHttpRequestMethodNotSupportedException",e);
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
 
-        final ErrorResponse response =ErrorResponse.of(CommonErrorCode.INVALID_HTTP_REQUEST_METHOD);
+        final ErrorResponse response = ErrorResponse.of(CommonErrorCode.INVALID_HTTP_REQUEST_METHOD);
 
-        return new ResponseEntity<>(response,HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
@@ -104,10 +104,16 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public final ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, WebRequest request) {
-        log.error("handleMethodArgumentNotValid", e);
-        ErrorResponse response = ErrorResponse.of(CommonErrorCode.INVALID_WORD_PARAMETER);
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
 
+        String defaultMessage = e.getBindingResult().getFieldError().getDefaultMessage();
+        if (!StringUtils.isBlank(defaultMessage)) {
+            defaultMessage = String.format(" (%s)", defaultMessage);
+        }
+
+        final ErrorResponse response = ErrorResponse.of(CommonErrorCode.ARGUMENT_VALIDATION_FAILED, defaultMessage);
+        
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/module-common/src/main/java/com/kernel360/response/ErrorResponse.java
+++ b/module-common/src/main/java/com/kernel360/response/ErrorResponse.java
@@ -14,4 +14,12 @@ public record ErrorResponse(
                 code.getMessage()
         );
     }
+
+    public static ErrorResponse of(ErrorCode code, String detailMessage) {
+        return new ErrorResponse(
+                code.getStatus(),
+                code.getCode(),
+                code.getMessage() + detailMessage
+        );
+    }
 }


### PR DESCRIPTION
## 💡 Motivation and Context
`1) 제품/세차장 리뷰 도메인에 비속어 필터링 적용`
`2) 관련 글로벌 Exception 수정`

<br>

## 🔨 Modified
> 비속어 필터링 일부 내용 수정 및 도메인에 적용 
  - _비속어 필터링 글로벌 익셉션 부분 수정_
  - _세차장 리뷰 도메인에 추가 적용_
  - _ValidationMessage 파일 추가_

<br>

## 🌟 More
- _flyway sql 모듈 이동_
- _개발-API, 배치 / 운영-배치 모듈 이미지 ecr로 올리기 위한 작업_
- _파일 확장자 검증 로직 추가_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #302 
closes #303 
