### PR TITLE
[feat] REST Docs + Swagger UI

### DIFF
--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -1,8 +1,15 @@
+buildscript {
+    ext {
+        restdocsApiSpecVersion = '0.17.1'
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.4'
-    id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id 'com.epages.restdocs-api-spec' version "${restdocsApiSpecVersion}"
+    id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'com.kernel360'
@@ -10,10 +17,6 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'
-}
-
-ext {
-    snippetsDir = file('build/generated-snippets')
 }
 
 configurations {
@@ -35,7 +38,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
@@ -66,9 +68,10 @@ dependencies {
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.0")
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-jakarta-validation:1.0.0")
 
-    // rest docs
+    // rest docs & swagger
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:' + restdocsApiSpecVersion
+    swaggerUI 'org.webjars:swagger-ui:4.11.1'
 
     //actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -85,30 +88,42 @@ dependencies {
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
-    //badword Filtering
+    // badword Filtering
     implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
 
-
-    // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
-    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+    // commons-collections4
+    implementation 'org.apache.commons:commons-collections4:4.4'
 
 }
 
 tasks.named('test') {
-    outputs.dir snippetsDir
     useJUnitPlatform()
 }
 
-asciidoctor {
-    baseDirFollowsSourceFile()
-    inputs.dir snippetsDir
-    configurations 'asciidoctorExt'
-    dependsOn test
+tasks.withType(GenerateSwaggerUI) {
+    dependsOn 'openapi3'
+}
+
+swaggerSources {
+    sample {
+        setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+    }
+}
+
+openapi3 {
+    servers = [
+        { url = "https://devapi.washfit.site" },
+        { url = "http://localhost:8080" }
+    ]
+    title = "API Document"
+    description = "Rest Docs With Swagger"
+    version = "0.0.1"
+    format = "yaml"
 }
 
 bootJar {
-    dependsOn asciidoctor
-    from ("${asciidoctor.outputDir}") {
+    dependsOn generateSwaggerUISample
+    from("${generateSwaggerUISample.outputDir}") {
         into 'static/docs'
     }
 }

--- a/module-api/src/main/java/com/kernel360/global/filter/LogFilter.java
+++ b/module-api/src/main/java/com/kernel360/global/filter/LogFilter.java
@@ -61,7 +61,7 @@ public class LogFilter implements Filter {
         });
 
         String responseBody = new String(response.getContentAsByteArray());
-        if(!deninedList().containsKey(uri)) {
+        if(!deninedList().containsKey(uri) && !uri.startsWith("/docs/")) {
             log.info("##### RESPONSE ##### uri: {}, method: {}, header: {}, body: {}", uri, method, responseHeaderValues, responseBody);
         }
         response.copyBodyToResponse();

--- a/module-api/src/test/java/com/kernel360/common/ControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/common/ControllerTest.java
@@ -6,6 +6,7 @@ import com.kernel360.auth.service.AuthService;
 import com.kernel360.commoncode.controller.CommonCodeController;
 import com.kernel360.commoncode.service.CommonCodeService;
 import com.kernel360.global.Interceptor.AcceptInterceptor;
+import com.kernel360.global.Interceptor.InterceptorConfig;
 import com.kernel360.main.controller.MainController;
 import com.kernel360.main.service.MainService;
 import com.kernel360.member.controller.MemberController;
@@ -14,6 +15,8 @@ import com.kernel360.member.service.MemberService;
 import com.kernel360.mypage.controller.MyPageController;
 import com.kernel360.product.controller.ProductController;
 import com.kernel360.product.service.ProductService;
+import com.kernel360.review.controller.ReviewController;
+import com.kernel360.review.service.ReviewService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -26,7 +29,8 @@ import org.springframework.test.web.servlet.MockMvc;
         ProductController.class,
         MainController.class,
         MyPageController.class,
-        AuthController.class
+        AuthController.class,
+        ReviewController.class
 })
 @AutoConfigureRestDocs
 public abstract class ControllerTest {
@@ -36,6 +40,9 @@ public abstract class ControllerTest {
 
     @Autowired
     protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected InterceptorConfig interceptorConfig;
 
     @MockBean
     protected AcceptInterceptor acceptInterceptor;
@@ -57,4 +64,7 @@ public abstract class ControllerTest {
 
     @MockBean
     protected AuthService authService;
+
+    @MockBean
+    protected ReviewService reviewService;
 }

--- a/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerRestDocsTest.java
+++ b/module-api/src/test/java/com/kernel360/commoncode/controller/CommonCodeControllerRestDocsTest.java
@@ -1,25 +1,26 @@
 package com.kernel360.commoncode.controller;
 
-import static com.kernel360.common.utils.RestDocumentUtils.getDocumentRequest;
-import static com.kernel360.common.utils.RestDocumentUtils.getDocumentResponse;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import com.kernel360.common.ControllerTest;
 import com.kernel360.commoncode.dto.CommonCodeDto;
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.kernel360.common.utils.RestDocumentUtils.getDocumentRequest;
+import static com.kernel360.common.utils.RestDocumentUtils.getDocumentResponse;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 // FIXME :: 삭제 예정 파일입니다
 class CommonCodeControllerRestDocsTest extends ControllerTest {
@@ -64,39 +65,38 @@ class CommonCodeControllerRestDocsTest extends ControllerTest {
 
 
         //then
-        //pathParameters, pathParameters, requestFields, responseFields는 필요 시 각각 작성
         result.andExpect(status().isOk())
               .andDo(document(
                       "commoncode/get-common-codes",
                       getDocumentRequest(),
                       getDocumentResponse(),
-                      pathParameters(
-                              parameterWithName("codeName").description("코드명")
-                      ),
-//                      queryParameters(
-//                              parameterWithName("size").description("size").optional(),
-//                              parameterWithName("page").description("page").optional()
-//                      ),
-//                      requestFields(
-//                              fieldWithPath("codeName").type(JsonFieldType.STRING).description("코드명"),
-//                              fieldWithPath("upperName").type(JsonFieldType.STRING).description("상위 코드명").optional()
-//                      ),
-//                      responseFields(
-//                              fieldWithPath("codeNo").type(JsonFieldType.NUMBER).description("코드번호"),
-//                      )
-                      responseFields(beneathPath("value").withSubsectionId("value"),
-                              fieldWithPath("codeNo").type(JsonFieldType.NUMBER).description("코드번호"),
-                              fieldWithPath("codeName").type(JsonFieldType.STRING).description("코드명"),
-                              fieldWithPath("upperNo").type(JsonFieldType.NUMBER).description("상위 코드번호").optional(),
-                              fieldWithPath("upperName").type(JsonFieldType.STRING).description("상위 코드명").optional(),
-                              fieldWithPath("sortOrder").type(JsonFieldType.NUMBER).description("정렬순서"),
-                              fieldWithPath("isUsed").type(JsonFieldType.BOOLEAN).description("사용여부"),
-                              fieldWithPath("description").type(JsonFieldType.STRING).description("설명"),
-                              fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성일시"),
-                              fieldWithPath("createdBy").type(JsonFieldType.STRING).description("생성자"),
-                              fieldWithPath("modifiedAt").type(JsonFieldType.STRING).description("수정일시").optional(),
-                              fieldWithPath("modifiedBy").type(JsonFieldType.STRING).description("수정자").optional()
-                      )
-              ));
+                      resource(ResourceSnippetParameters
+                              .builder()
+                              .tag("CommonCode API")
+                              .summary("공통코드 조회")
+                              .pathParameters(
+                                      parameterWithName("codeName").description("코드명")
+                              )
+                              .responseFields(
+                                      fieldWithPath("status").type(JsonFieldType.NUMBER).description("상태"),
+                                      fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                      fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                      fieldWithPath("value").type(JsonFieldType.ARRAY).description("응답 데이터 리스트"),
+                                      fieldWithPath("value[].codeNo").type(JsonFieldType.NUMBER).description("코드번호"),
+                                      fieldWithPath("value[].codeName").type(JsonFieldType.STRING).description("코드명"),
+                                      fieldWithPath("value[].upperNo").type(JsonFieldType.NUMBER).description("상위 코드번호").optional(),
+                                      fieldWithPath("value[].upperName").type(JsonFieldType.STRING).description("상위 코드명").optional(),
+                                      fieldWithPath("value[].sortOrder").type(JsonFieldType.NUMBER).description("정렬순서"),
+                                      fieldWithPath("value[].isUsed").type(JsonFieldType.BOOLEAN).description("사용여부"),
+                                      fieldWithPath("value[].description").type(JsonFieldType.STRING).description("설명"),
+                                      fieldWithPath("value[].createdAt").type(JsonFieldType.STRING).description("생성일시"),
+                                      fieldWithPath("value[].createdBy").type(JsonFieldType.STRING).description("생성자"),
+                                      fieldWithPath("value[].modifiedAt").type(JsonFieldType.STRING).description("수정일시").optional(),
+                                      fieldWithPath("value[].modifiedBy").type(JsonFieldType.STRING).description("수정자").optional()
+                              )
+                              .requestSchema(Schema.schema("공통코드 조회"))
+                              .responseSchema(Schema.schema("공통코드 조회"))
+                              .build()
+                      )));
     }
 }

--- a/module-api/src/test/java/com/kernel360/review/controller/ReviewControllerTest.java
+++ b/module-api/src/test/java/com/kernel360/review/controller/ReviewControllerTest.java
@@ -1,0 +1,193 @@
+package com.kernel360.review.controller;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.kernel360.common.ControllerTest;
+import com.kernel360.member.dto.MemberDto;
+import com.kernel360.product.dto.ProductDetailDto;
+import com.kernel360.review.dto.ReviewResponseDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.kernel360.common.utils.RestDocumentUtils.getDocumentRequest;
+import static com.kernel360.common.utils.RestDocumentUtils.getDocumentResponse;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ReviewControllerTest extends ControllerTest {
+
+    @Test
+    void 리뷰_단건조회() throws Exception {
+        // given
+        ReviewResponseDto response = ReviewResponseDto.of(
+                302L,
+                ProductDetailDto.of(
+                        63418L,
+                        "파이널 폴리쉬",
+                        null,
+                        "(주)오토왁스",
+                        "코팅제품",
+                        "광택코팅제"
+                ),
+                MemberDto.of(
+                        251L,
+                        "wa*******",
+                        0,
+                        0
+                ),
+                BigDecimal.valueOf(1.5),
+                "10306 수정 타이틀",
+                "10306 수정 contents",
+                LocalDateTime.parse("2024-03-05T00:00:00"),
+                "admin",
+                LocalDateTime.parse("2024-03-06T00:00:00"),
+                "admin",
+                Arrays.asList()
+        );
+
+        Long reviewNo = 302L;
+        given(reviewService.getReview(reviewNo)).willReturn(response);
+
+
+        // when
+        ResultActions result = this.mockMvc.perform(get("/reviews/{reviewNo}", reviewNo));
+
+
+        // then
+        result.andExpect(status().isOk())
+              .andDo(document(
+                      "reviews/get-review",
+                      getDocumentRequest(),
+                      getDocumentResponse(),
+                      resource(ResourceSnippetParameters
+                              .builder()
+                              .tag("Review API")
+                              .summary("리뷰 단건 조회")
+                              .pathParameters(
+                                      parameterWithName("reviewNo").description("리뷰번호")
+                              )
+                              .responseFields(
+                                      fieldWithPath("status").type(JsonFieldType.NUMBER).description("상태"),
+                                      fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                      fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                      fieldWithPath("value").type(JsonFieldType.OBJECT).description("응답 데이터 리스트"),
+                                      fieldWithPath("value.reviewNo").type(JsonFieldType.NUMBER).description("리뷰번호"),
+                                      fieldWithPath("value.starRating").type(JsonFieldType.NUMBER).description("별점"),
+                                      fieldWithPath("value.title").type(JsonFieldType.STRING).description("제목"),
+                                      fieldWithPath("value.contents").type(JsonFieldType.STRING).description("내용"),
+                                      fieldWithPath("value.createdAt").type(JsonFieldType.STRING).description("생성일시"),
+                                      fieldWithPath("value.createdBy").type(JsonFieldType.STRING).description("생성자"),
+                                      fieldWithPath("value.modifiedAt").type(JsonFieldType.STRING).description("수정일시").optional(),
+                                      fieldWithPath("value.modifiedBy").type(JsonFieldType.STRING).description("수정자").optional(),
+                                      fieldWithPath("value.files").type(JsonFieldType.ARRAY).description("파일 URL 리스트"),
+                                      fieldWithPath("value.product").type(JsonFieldType.OBJECT).description("제품 정보"),
+                                      fieldWithPath("value.product.productNo").type(JsonFieldType.NUMBER).description("제품번호"),
+                                      fieldWithPath("value.product.productName").type(JsonFieldType.STRING).description("제품명"),
+                                      fieldWithPath("value.product.imageSource").type(JsonFieldType.VARIES).description("이미지 (문자열 또는 null)"),
+                                      fieldWithPath("value.product.companyName").type(JsonFieldType.STRING).description("회사명"),
+                                      fieldWithPath("value.product.upperItem").type(JsonFieldType.STRING).description("상위 타입"),
+                                      fieldWithPath("value.product.item").type(JsonFieldType.STRING).description("타입"),
+                                      fieldWithPath("value.product.barcode").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.reportNumber").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.safetyStatus").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.viewCount").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.productType").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.issuedDate").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.safetyInspectionStandard").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.propose").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.weight").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.usage").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.usagePrecaution").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.firstAid").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.mainSubstance").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.allergicSubstance").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.otherSubstance").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.preservative").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.surfactant").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.fluorescentWhitening").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.manufactureType").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.manufactureMethod").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.manufactureNation").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.violationInfo").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.createdAt").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.createdBy").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.modifiedAt").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.product.modifiedBy").type(JsonFieldType.NULL).description("타입"),
+                                      fieldWithPath("value.member").type(JsonFieldType.OBJECT).description("회원 정보"),
+                                      fieldWithPath("value.member.memberNo").type(JsonFieldType.NUMBER).description("회원번호"),
+                                      fieldWithPath("value.member.id").type(JsonFieldType.STRING).description("ID"),
+                                      fieldWithPath("value.member.age").type(JsonFieldType.STRING).description("나이"),
+                                      fieldWithPath("value.member.gender").type(JsonFieldType.STRING).description("성별"),
+                                      fieldWithPath("value.member.email").type(JsonFieldType.NULL).description("성별"),
+                                      fieldWithPath("value.member.password").type(JsonFieldType.NULL).description("성별"),
+                                      fieldWithPath("value.member.createdAt").type(JsonFieldType.NULL).description("성별"),
+                                      fieldWithPath("value.member.createdBy").type(JsonFieldType.NULL).description("성별"),
+                                      fieldWithPath("value.member.modifiedAt").type(JsonFieldType.NULL).description("성별"),
+                                      fieldWithPath("value.member.modifiedBy").type(JsonFieldType.NULL).description("성별"),
+                                      fieldWithPath("value.member.jwtToken").type(JsonFieldType.NULL).description("성별")
+                              )
+                              .requestSchema(Schema.schema("리뷰 단건 조회"))
+                              .responseSchema(Schema.schema("리뷰 단건 조회"))
+                              .build()
+                      )));
+    }
+
+    @Test
+    void 리뷰등록() throws Exception {
+        // given
+        String reviewJson = "{\"productNo\": 63354, \"memberNo\": 201, \"starRating\": 1.0, \"title\": \"제목\", \"contents\": \"내용\"}";
+
+        MockMultipartFile review = new MockMultipartFile("review", "review.json", "application/json", reviewJson.getBytes());
+        MockMultipartFile file1 = new MockMultipartFile("files", "flower-1.png", "image/png", "<<flower-1.png data>>".getBytes());
+        MockMultipartFile file2 = new MockMultipartFile("files", "space-1.jpg", "image/jpeg", "<<space-1.jpg data>>".getBytes());
+
+
+        // when
+        ResultActions result = this.mockMvc.perform(multipart("/reviews")
+                .file(review)
+                .file(file1)
+                .file(file2)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .header("Id", "member01")
+        );
+
+
+        // then
+        result.andExpect(status().isOk())
+              .andDo(document(
+                      "reviews/create-review",
+                      getDocumentRequest(),
+                      getDocumentResponse(),
+                      requestParts(
+                              partWithName("files").description("파일 리스트"),
+                              partWithName("review").description("리뷰 데이터")
+                      ),
+                      resource(ResourceSnippetParameters
+                              .builder()
+                              .tag("Review API")
+                              .summary("리뷰 등록")
+                              .responseFields(
+                                      fieldWithPath("status").type(JsonFieldType.NUMBER).description("상태"),
+                                      fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                                      fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                      fieldWithPath("value").type(JsonFieldType.NULL).description("응답 데이터")
+                              )
+                              .requestSchema(Schema.schema("리뷰 등록"))
+                              .responseSchema(Schema.schema("리뷰 등록"))
+                              .build()
+                      )));
+    }
+}


### PR DESCRIPTION
## 💡 Motivation and Context
`REST Docs + Swagger UI`

<br>

## 🔨 Modified
> REST Docs + Swagger UI
  - _build.gradle에 관련 설정 추가_
  - _LogFilter 내 Response 로그 관련 수정_
     - /docs/ 하위 내용에 대해 응답로그 남기지 X
  - CommonCodeControllerRestDocsTest.java (예시 내용 변경)
  - 리뷰 단건 조회, 리뷰 등록 예시 추가
     - 단, 구두로 말씀드렸듯이.. 파일 업로드 기능은 테스트 불가합니다
 > 리뷰 테스트하면서 @MockBean 으로 InterceptorConfig 추가함

 > 테스트 방식은 아래 내용을 참고해주세요
 - gradle build 시 아래 경로에 index.html 파일이 생성됨
    - 실제 테스트가 아닌 html 형태 확인은 해당 파일을 브라우저나 인텔리제이로 열어 확인 가능합니다
![image](https://github.com/Kernel360/F1-WashFit-BE/assets/88479739/e4136db5-91ec-483e-ae42-a17a21800727)
 - 실제 http://localhost:8080/docs/index.html 경로에 접근하여 테스트할 시, 터미널에서 java -jar 명령어 실행해서 서버 띄워야합니다
    - jar 파일 내 경로에 해당 index.html 위치함
    <img width="603" alt="image" src="https://github.com/Kernel360/F1-WashFit-BE/assets/88479739/7a0d2813-73c2-4d08-ac34-94382c46a303">
 ```shell
> cd module-api
> ./gradlew build
> java -jar build/libs/module-api-0.0.1-SNAPSHOT.jar --jasypt.encryptor.password=???
 ```
 - 기본 경로는 개발서버로 되어있기 때문에, (로컬 테스트 시에는) 로컬로 변경해야 오류 발생하지 않습니다
    <img width="296" alt="image" src="https://github.com/Kernel360/F1-WashFit-BE/assets/88479739/56020d6e-d477-4803-abb4-e7818f80b8c8">
 

<br>

## 🌟 More
- _성능 개선 리팩토링_
- _파일 확장자 검증 로직 추가_
- _경우에 따라.. 위 기능을 활용한 테스트코드 작성_

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #311
