### PR TITLE
[feat] 파일 확장자 검증 로직 추가

### DIFF
--- a/module-api/src/main/java/com/kernel360/review/service/ReviewService.java
+++ b/module-api/src/main/java/com/kernel360/review/service/ReviewService.java
@@ -24,9 +24,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+
+import static org.springframework.util.MimeTypeUtils.*;
 
 @Slf4j
 @Service
@@ -44,6 +47,7 @@ public class ReviewService {
     private static final double MAX_STAR_RATING = 5.0;
     private static final String REVIEW_DOMAIN = FileReferType.REVIEW.getDomain();
     private static final String REVIEW_CODE = FileReferType.REVIEW.getCode();
+    private static final List<String> ALLOWED_FILE_TYPE = Arrays.asList(IMAGE_JPEG_VALUE, IMAGE_PNG_VALUE, IMAGE_GIF_VALUE);
 
     @Transactional(readOnly = true)
     public Page<ReviewResponseDto> getReviewsByProduct(Long productNo, String sortBy, Pageable pageable) {
@@ -77,6 +81,7 @@ public class ReviewService {
     public Review createReview(ReviewRequestDto reviewRequestDto, List<MultipartFile> files, String id) {
         isValidMemberInfo(id, reviewRequestDto.memberNo());
         isValidStarRating(reviewRequestDto.starRating());
+        fileUtils.isValidFileExtension(files, ALLOWED_FILE_TYPE);
 
         Review review;
 
@@ -120,6 +125,7 @@ public class ReviewService {
         Review review = isVisibleReview(reviewRequestDto.reviewNo());
         isValidMemberInfo(id, review.getMember().getMemberNo());
         isValidStarRating(reviewRequestDto.starRating());
+        fileUtils.isValidFileExtension(files, ALLOWED_FILE_TYPE);
 
         long productNo = review.getProduct().getProductNo();
 

--- a/module-api/src/main/java/com/kernel360/washzonereview/service/WashzoneReviewService.java
+++ b/module-api/src/main/java/com/kernel360/washzonereview/service/WashzoneReviewService.java
@@ -24,9 +24,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+
+import static org.springframework.util.MimeTypeUtils.*;
 
 @Slf4j
 @Service
@@ -43,6 +46,7 @@ public class WashzoneReviewService {
     private static final double MAX_STAR_RATING = 5.0;
     private static final String WASHZONE_REVIEW_DOMAIN = FileReferType.WASHZONE_REVIEW.getDomain();
     private static final String WASHZONE_REVIEW_CODE = FileReferType.WASHZONE_REVIEW.getCode();
+    private static final List<String> ALLOWED_FILE_TYPE = Arrays.asList(IMAGE_JPEG_VALUE, IMAGE_PNG_VALUE, IMAGE_GIF_VALUE);
 
     @Transactional(readOnly = true)
     public Page<WashzoneReviewResponseDto> getWashzoneReviewsByWashzone(Long washzoneNo, String sortBy, Pageable pageable) {
@@ -76,6 +80,7 @@ public class WashzoneReviewService {
     public WashzoneReview createWashzoneReview(WashzoneReviewRequestDto requestDto, List<MultipartFile> files, String id) {
         isValidMemberInfo(id, requestDto.memberNo());
         isValidStarRating(requestDto.starRating());
+        fileUtils.isValidFileExtension(files, ALLOWED_FILE_TYPE);
 
         WashzoneReview washzoneReview;
 
@@ -119,6 +124,7 @@ public class WashzoneReviewService {
         WashzoneReview washzoneReview = isVisibleStatus(requestDto.washzoneReviewNo());
         isValidMemberInfo(id, washzoneReview.getMember().getMemberNo());
         isValidStarRating(requestDto.starRating());
+        fileUtils.isValidFileExtension(files, ALLOWED_FILE_TYPE);
 
         long washzoneNo = washzoneReview.getWashzone().getWashZoneNo();
 

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     // aws s3
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.625'
 
+    // apache tika
+    implementation 'org.apache.tika:tika-core:2.9.1'
+
     // commons-lang3
     implementation 'org.apache.commons:commons-lang3:3.12.0'
 }

--- a/module-common/src/main/java/com/kernel360/code/common/CommonErrorCode.java
+++ b/module-common/src/main/java/com/kernel360/code/common/CommonErrorCode.java
@@ -12,7 +12,8 @@ public enum CommonErrorCode implements ErrorCode {
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST.value(),  "E006", "요청 파라미터가 없거나 비어있거나, 요청 파라미터의 이름이 메서드 인수의 이름과 일치하지 않습니다"),
     INVALID_HTTP_REQUEST_METHOD(HttpStatus.BAD_REQUEST.value(),  "E007", "요청 URL 에서 지원하지 않는 HTTP Method 입니다."),
     INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST.value(),  "E008", "요청한 파라미터가 존재하지 않음"),
-    ARGUMENT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST.value(),  "E009", "유효하지 않은 데이터가 존재함");
+    ARGUMENT_VALIDATION_FAILED(HttpStatus.BAD_REQUEST.value(),  "E009", "유효하지 않은 데이터가 존재함"),
+    FAIL_FILE_EXTENSION_VALIDATE(HttpStatus.INTERNAL_SERVER_ERROR.value(),  "E010", "파일 확장자 검증 실패");
 
     private final int status;
     private final String code;


### PR DESCRIPTION
## 💡 Motivation and Context
`파일 확장자 검증 로직 추가`

<br>

## 🔨 Modified
> 파일 확장자 검증
  - _apache tika 라이브러리 사용_
  - _FileUtils 파일에 파일 확장자 검증 로직 보완_
  - _제품 리뷰 및 세차장 리뷰 등록/수정 로직에 해당 검증 내용 추가_

> 파일 확장자 검증 로직 설명
  - _기본 방식_
      - _tika 라이브러리를 통해 검증한 실제 파일의 MIME Type (ex> image/png) 기준으로 extention list를 가져와 업로드 파일의 확장자가 포함되는지 체크_
  ```java
   isValidFileExtension(List<MultipartFile> files)
  ```
  - _업로드 허용 파일타입에 제한을 두는 경우 (프론트에서도 제한 두겠지만 필요한 경우 사용하면 됩니다)_
      - _아래 메서드 호출 시 기본 방식에 대한 검증을 통과한 후 추가적으로 검증합니다_
      - _서비스에서 허용한 MIME Type 기준의 extention list를 만들어 해당 파일의 확장자가 업로드 가능한지 체크_
  ```java
   isValidFileExtension(List<MultipartFile> files, List<String> allowedFileType)
   ```
<br>

## 🌟 More
- _리팩토링 작업_
- _..._

<br>

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [x] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #315 
