### PR TITLE
feature :: 게시판 첨부파일 기능 추가

### DIFF
--- a/module-api/src/main/java/com/kernel360/bbs/code/BBSErrorCode.java
+++ b/module-api/src/main/java/com/kernel360/bbs/code/BBSErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum BBSErrorCode implements ErrorCode {
 
     FAILED_GET_BBS_LIST(HttpStatus.NO_CONTENT.value(), "BMC001", "게시판 목록을 찾을 수 없음."),
-    FAILED_GET_BBS_VIEW(HttpStatus.NO_CONTENT.value(), "BMC002", "게시글을 찾을 수 없음.");
+    FAILED_GET_BBS_VIEW(HttpStatus.NO_CONTENT.value(), "BMC002", "게시글을 찾을 수 없음."),
+    UNSUPPORTED_API_VERSION(HttpStatus.BAD_REQUEST.value(), "BMC003", "지원하지않는 API버전. API 버전을 다시 확인하세요.");
 
     private final int status;
     private final String code;

--- a/module-api/src/main/java/com/kernel360/bbs/controller/BBSController.java
+++ b/module-api/src/main/java/com/kernel360/bbs/controller/BBSController.java
@@ -8,54 +8,76 @@ import com.kernel360.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/bbs")
 public class BBSController {
     private final BBSService bbsService;
 
-    @GetMapping("/bbs")
-    public ResponseEntity<ApiResponse<Page<BBSListDto>>> getBBS(
+    @GetMapping("/v1")
+    public ResponseEntity<ApiResponse<Page<BBSListDto>>> getBBSv1(
             @RequestParam(value = "type", defaultValue = "") String type,
-            @RequestParam(value = "keyword", required = false) String keyword, Pageable pageable
+            @RequestParam(value = "keyword", required = false) String keyword,
+            Pageable pageable
     ){
-        Page<BBSListDto> result = bbsService.getBBSWithCondition(type, keyword, pageable);
 
-        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS, result);
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS, bbsService.getBBSWithConditionByPage(type, keyword, pageable));
     }
 
-    @GetMapping("/bbs/{bbsNo}")
+    @GetMapping("/v2")
+    public ResponseEntity<ApiResponse<Slice<BBSListDto>>> getBBSv2(
+            @RequestParam(value = "type", defaultValue = "") String type,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            Pageable pageable
+    ){
+
+        return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS, bbsService.getBBSWithConditionBySlice(type, keyword, pageable));
+    }
+
+    @GetMapping("/{bbsNo}")
     public ResponseEntity<ApiResponse<BBSDto>> getBBSView(@PathVariable Long bbsNo){
 
         return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS_VIEW, bbsService.getBBSView(bbsNo));
     }
 
-    @GetMapping("/bbs/reply")
+    @GetMapping("/reply")
     public ResponseEntity<ApiResponse<Page<BBSDto>>> getBBSReply(@RequestParam Long upperNo, Pageable pageable){
 
         return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_GET_BBS_VIEW, bbsService.getBBSReply(upperNo, pageable));
     }
 
-    @PostMapping("/bbs")
-    public ResponseEntity<ApiResponse<BBSDto>> saveBBS(@RequestBody BBSDto bbsDto, @RequestHeader("Id") String id){
-
-        bbsService.saveBBS(bbsDto, id);
+    @PostMapping("")
+    public ResponseEntity<ApiResponse<BBSDto>> saveBBS(
+            @RequestPart BBSDto bbsDto,
+            @RequestHeader("Id") String id,
+            @RequestPart(required = false) List<MultipartFile> files
+    ){
+        bbsService.saveBBS(bbsDto, id, files);
 
         return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_CREATED_BBS);
     }
 
-    @PatchMapping("/bbs")
-    public ResponseEntity<ApiResponse<BBSDto>> modifyBBS(@RequestBody BBSDto bbsDto, @RequestHeader("Id") String id){
+    @PatchMapping("")
+    public ResponseEntity<ApiResponse<BBSDto>> modifyBBS(
+            @RequestPart BBSDto bbsDto,
+            @RequestHeader("Id") String id,
+            @RequestPart(required = false) List<MultipartFile> files
+    ){
 
-        bbsService.saveBBS(bbsDto, id);
+        bbsService.saveBBS(bbsDto, id, files);
 
         return ApiResponse.toResponseEntity(BBSBusinessCode.SUCCESS_REQUEST_MODIFIED_BBS);
     }
 
-    @DeleteMapping("/bbs")
-    public ResponseEntity<ApiResponse<BBSDto>> deleteBBS(@RequestParam Long bbsNo){
+    @DeleteMapping("/{bbsNo}")
+    public ResponseEntity<ApiResponse<BBSDto>> deleteBBS(@PathVariable Long bbsNo){
 
         bbsService.deleteBBS(bbsNo);
 

--- a/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
+++ b/module-api/src/main/java/com/kernel360/bbs/dto/BBSDto.java
@@ -1,14 +1,17 @@
 package com.kernel360.bbs.dto;
 
 import com.kernel360.bbs.entity.BBS;
+import com.kernel360.file.entity.File;
 import com.kernel360.member.dto.MemberDto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * DTO for {@link com.kernel360.bbs.entity.BBS}
  */
 public record BBSDto(
+
         Long bbsNo,
         Long upperNo,
         String type,
@@ -20,7 +23,8 @@ public record BBSDto(
         LocalDateTime modifiedAt,
         String modifiedBy,
         Long viewCount,
-        MemberDto memberDto
+        MemberDto memberDto,
+        List<File> files
     ) {
 
     public static BBSDto of(
@@ -35,7 +39,8 @@ public record BBSDto(
             LocalDateTime modifiedAt,
             String modifiedBy,
             Long viewCount,
-            MemberDto memberDto
+            MemberDto memberDto,
+            List<File> files
     ){
         return new BBSDto(
             bbsNo,
@@ -49,11 +54,12 @@ public record BBSDto(
             modifiedAt,
             modifiedBy,
             viewCount,
-            memberDto
+            memberDto,
+                files
         );
     }
 
-    public static BBSDto from(BBS entity){
+    public static BBSDto from(BBS entity, List<File> byReferenceTypeAndReferenceNo){
         return new BBSDto(
                 entity.getBbsNo(),
                 entity.getUpperNo(),
@@ -66,21 +72,9 @@ public record BBSDto(
                 entity.getModifiedAt(),
                 entity.getModifiedBy(),
                 entity.getViewCount(),
-                MemberDto.from(entity.getMember())
+                MemberDto.from(entity.getMember()),
+                byReferenceTypeAndReferenceNo
         );
     }
-
-
-//    public BBS toEntity() {
-//        return BBS.create(
-//                this.bbsNo(),
-//                this.upperNo(),
-//                this.title(),
-//                this.contents()
-//
-//        );
-//    }
-
-
 
 }

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepository.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepository.java
@@ -4,9 +4,11 @@ import com.kernel360.bbs.dto.BBSListDto;
 import com.kernel360.bbs.entity.BBS;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface BBSRepository extends BBSRepositoryJPA, BBSRepositoryDSL {
-    Page<BBSListDto> getBBSWithCondition(String type, String keyword, Pageable pageable);
+    Page<BBSListDto> getBBSWithConditionByPage(String type, String keyword, Pageable pageable);
+    Slice<BBSListDto> getBBSWithConditionBySlice(String type, String keyword, Pageable pageable);
 
     BBS findOneByBbsNo(Long bbsNo);
 

--- a/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSL.java
+++ b/module-api/src/main/java/com/kernel360/bbs/repository/BBSRepositoryDSL.java
@@ -3,7 +3,10 @@ package com.kernel360.bbs.repository;
 import com.kernel360.bbs.dto.BBSListDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface BBSRepositoryDSL {
-    Page<BBSListDto> getBBSWithCondition(String bbsType, String keyword, Pageable pageable);
+    Page<BBSListDto> getBBSWithConditionByPage(String bbsType, String keyword, Pageable pageable);
+
+    Slice<BBSListDto> getBBSWithConditionBySlice(String bbsType, String keyword, Pageable pageable);
 }

--- a/module-api/src/main/java/com/kernel360/bbs/service/BBSService.java
+++ b/module-api/src/main/java/com/kernel360/bbs/service/BBSService.java
@@ -1,48 +1,96 @@
 package com.kernel360.bbs.service;
 
+import com.kernel360.bbs.code.BBSErrorCode;
 import com.kernel360.bbs.dto.BBSDto;
 import com.kernel360.bbs.dto.BBSListDto;
 import com.kernel360.bbs.entity.BBS;
 import com.kernel360.bbs.repository.BBSRepository;
+import com.kernel360.exception.BusinessException;
+import com.kernel360.file.entity.File;
+import com.kernel360.file.entity.FileReferType;
+import com.kernel360.file.repository.FileRepository;
+import com.kernel360.member.code.MemberErrorCode;
 import com.kernel360.member.dto.MemberDto;
 import com.kernel360.member.service.MemberService;
+import com.kernel360.utils.file.FileUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BBSService {
+    private final FileUtils fileUtils;
     private final BBSRepository bbsRepository;
     private final MemberService memberService;
+    private final FileRepository fileRepository;
 
-    public Page<BBSListDto> getBBSWithCondition(String type, String keyword, Pageable pageable) {
+    @Value("${aws.s3.bucket.url}")
+    private String bucketUrl;
+    private static final String REFERENCE_TYPE = "BBS";
 
-        return bbsRepository.getBBSWithCondition(type, keyword, pageable);
+    public Page<BBSListDto> getBBSWithConditionByPage(String type, String keyword, Pageable pageable) {
+
+        return bbsRepository.getBBSWithConditionByPage(type, keyword, pageable);
+    }
+
+    public Slice<BBSListDto> getBBSWithConditionBySlice(String type, String keyword, Pageable pageable) {
+
+        return bbsRepository.getBBSWithConditionBySlice(type, keyword, pageable);
     }
 
     public BBSDto getBBSView(Long bbsNo) {
+        BBS entity = Optional.of(bbsRepository.findOneByBbsNo(bbsNo))
+                             .orElseThrow(() -> new BusinessException(BBSErrorCode.FAILED_GET_BBS_VIEW));
 
-        return BBSDto.from(bbsRepository.findOneByBbsNo(bbsNo));
+        BBSDto result = BBSDto.from(entity, fileRepository.findByReferenceTypeAndReferenceNo(REFERENCE_TYPE, entity.getBbsNo()));
+
+        return result;
     }
 
     public Page<BBSDto> getBBSReply(Long upperNo, Pageable pageable) {
 
-        return bbsRepository.findAllByUpperNo(upperNo, pageable).map(BBSDto::from);
+        return bbsRepository.findAllByUpperNo(upperNo, pageable).map(entity -> BBSDto.from(entity, fileRepository.findByReferenceTypeAndReferenceNo(REFERENCE_TYPE, entity.getBbsNo())));
     }
 
     @Transactional
-    public void saveBBS(BBSDto bbsDto, String id) {
+    public void saveBBS(BBSDto bbsDto, String id, List<MultipartFile> files) {
 
-        MemberDto memberDto = memberService.findByMemberId(id);
+        MemberDto memberDto = Optional.of(memberService.findByMemberId(id))
+                                      .orElseThrow(() -> new BusinessException(MemberErrorCode.FAILED_FIND_MEMBER_INFO));
 
-        bbsRepository.save(BBS.save(bbsDto.bbsNo(), bbsDto.upperNo(), bbsDto.type(), bbsDto.title(), bbsDto.contents(), true, 0L, memberDto.toEntity()));
+        BBS bbs = bbsRepository.save(BBS.save(bbsDto.bbsNo(), bbsDto.upperNo(), bbsDto.type(), bbsDto.title(), bbsDto.contents(), true, 0L, memberDto.toEntity()));
+
+        if(Objects.nonNull(files)){
+            uploadFiles(files, bbs.getBbsNo());
+        }
     }
 
     @Transactional
     public void deleteBBS(Long bbsNo) {
+
         bbsRepository.deleteByBbsNo(bbsNo);
+    }
+
+    private void uploadFiles(List<MultipartFile> files, Long bbsNo) {
+        files.stream().forEach(file -> {
+            String path = String.join("/", FileReferType.BBS.getDomain(), bbsNo.toString());
+            String fileKey = fileUtils.upload(path, file);
+            String fileUrl = String.join("/", bucketUrl, fileKey);
+
+            File fileInfo = fileRepository.save(File.of(null, file.getOriginalFilename(), fileKey, fileUrl, FileReferType.BBS.getCode(), bbsNo));
+            log.info("게시판 파일 등록 -> file_no {}", fileInfo.getFileNo());
+        });
     }
 }

--- a/module-domain/src/main/java/com/kernel360/file/entity/FileReferType.java
+++ b/module-domain/src/main/java/com/kernel360/file/entity/FileReferType.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FileReferType {
     REVIEW("review", "RV"),
-    WASHZONE_REVIEW("washzone-review", "WZRV");
+    WASHZONE_REVIEW("washzone-review", "WZRV"),
+    BBS("bbs", "BBS");
 
     private final String domain;
     private final String code;


### PR DESCRIPTION
## 💡 Motivation and Context
`여기에 왜 이 PR이 필요했는지, PR을 통해 무엇이 바뀌는지에 대해서 설명해 주세요`

<br>

- 게시판 등록, 수정, 조회시 첨부파일 정보도 같이 오도록 수정하였습니다.
- 목록조회시 jvm Xms 256mb, Xmx 512mb 환경에서 초기 조회 10회 평균 기존 700ms 를
  쿼리 수정하여 500ms -> slice 적용하여 400ms로 단축하였습니다.
- 첨부파일 정보는 적용시 프론트엔드 개발자와 협의하에 어떠한 정보를 보낼지 정리가 되면 그때 변경하도록 하겠습니다.

![스크린샷 2024-03-22 162914](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/ebf70a5d-e73f-4ebb-8a3a-bcf385f10882)
첨부파일 저장

![스크린샷 2024-03-22 162530](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/70202613-6163-4328-a350-08674775b69c)
첨부파일 조회

![스크린샷 2024-03-19 121211](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/f0454c8f-ae1a-4a10-a7d0-db10e7a5cf1f)
![스크린샷 2024-03-19 121253](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/6349ab1c-073f-470e-8c45-a250897b429a)
![스크린샷 2024-03-19 121301](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/acea808d-e8b3-414c-9dfc-532e1ed62feb)

JOIN절이 2중으로 걸려 딜레이 발생하여 한번만 조인되도록 수정하였습니다.

![스크린샷 2024-03-19 121516](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/0293abf1-5ae2-4d2e-84bb-7ac9f89798ba)
![스크린샷 2024-03-19 121604](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/6b896c55-54e6-46e3-a3b3-64280f8cfcd8) Page 조회시 500ms
![스크린샷 2024-03-19 123254](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/6c765aa1-2146-43b4-866d-0b8171202c6b) Slice로 변경하여 400ms


## 🔨 Modified
> 여기에 무엇이 크게 바뀌었는지 설명해 주세요
  - _여기에 세부 변경사항을 설명해주세요_

<br>

## 🌟 More
- _여기에 PR 이후 추가로 해야 할 일에 대해서 설명해 주세요_
<br>

- 테스트코드는 발표후에 시간날 때 천천히 하는것으로....

- API버저닝은 url을 쓰지말고 API헤더를 추가하여 같은 호출Mapping을 쓰되 버전마다 enum을 통해 매핑하여
  알맞는 method를 타게끔 적용하고 싶었는데 적용이 쉽지않아 일단은 보류하였습니다.
  이는 전략(Strategy) 패턴과 유사성을 가지고 있습니다.
 
![image](https://github.com/Kernel360/F1-WashFit-BE/assets/103917282/34fce05b-1d12-43ee-ae41-6b706fcc8538)
url 버저닝

---


### 📋 커밋 전 체크리스트
- [ ] 추가/변경에 대한 단위 테스트를 완료하였습니다.
- [ ] 컨벤션에 맞게 작성하였습니다.

<br>

### 🤟🏻 PR로 완료된 이슈
closes #
